### PR TITLE
Fix build errors in duckdb

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,9 +1,12 @@
 # bump: duckdb-version /DUCKDB_VERSION="(.*)"/ https://github.com/duckdb/duckdb.git|semver:*
 DUCKDB_VERSION="0.9.2"
 
-export ZOPEN_GIT_URL="https://github.com/duckdb/duckdb.git"
-export ZOPEN_GIT_DEPS="cmake make comp_clang ninja zoslib"
-export ZOPEN_TYPE="GIT"
+export ZOPEN_STABLE_URL="https://github.com/duckdb/duckdb.git"
+export ZOPEN_STABLE_DEPS="cmake make comp_clang ninja zoslib"
+export ZOPEN_STABLE_TAG="v$DUCKDB_VERSION"
+export ZOPEN_DEV_URL="https://github.com/duckdb/duckdb.git"
+export ZOPEN_DEV_DEPS="cmake make comp_clang ninja zoslib"
+export ZOPEN_BUILD_LINE="DEV"
 export ZOPEN_COMP=CLANG
 
 export ZOPEN_CONFIGURE="cmake"
@@ -50,7 +53,5 @@ zopen_append_to_setup()
 
 zopen_get_version()
 {
-  # Modify to echo the version of your tool/library
-  # Rather than hardcoding the version, obtain the version by running the tool/library
   echo "${DUCKDB_VERSION}"
 }

--- a/patches/entropy_poll.cpp.patch
+++ b/patches/entropy_poll.cpp.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/mbedtls/library/entropy_poll.cpp b/third_party/mbedtls/library/entropy_poll.cpp
+index 058c307dfb..c894fb6b3e 100644
+--- a/third_party/mbedtls/library/entropy_poll.cpp
++++ b/third_party/mbedtls/library/entropy_poll.cpp
+@@ -43,7 +43,7 @@
+ 
+ #if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
+     !defined(__APPLE__) && !defined(_WIN32) && !defined(__QNXNTO__) && \
+-    !defined(__HAIKU__) && !defined(__midipix__)
++    !defined(__HAIKU__) && !defined(__midipix__) && !defined(__MVS__)
+ #error "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h"
+ #endif
+ 

--- a/patches/linenoise.cpp.patch
+++ b/patches/linenoise.cpp.patch
@@ -1,0 +1,14 @@
+diff --git a/tools/shell/linenoise.cpp b/tools/shell/linenoise.cpp
+index 77cfb61c39..2bb9e13248 100644
+--- a/tools/shell/linenoise.cpp
++++ b/tools/shell/linenoise.cpp
+@@ -293,7 +293,9 @@ static int enableRawMode(int fd) {
+ 	/* output modes - disable post processing */
+ 	raw.c_oflag &= ~(OPOST);
+ 	/* control modes - set 8 bit chars */
++#ifndef __MVS__
+ 	raw.c_iflag |= IUTF8;
++#endif
+ 	raw.c_cflag |= CS8;
+ 	/* local modes - choing off, canonical off, no extended functions,
+ 	 * no signal chars (^Z,^C) */


### PR DESCRIPTION
* Avoid "Platform entropy sources only work on Unix and Windows, see MBEDTLS_NO_PLATFORM_ENTROPY in mbedtls_config.h" error
* IUTF8 doesn't exist on z/OS